### PR TITLE
Added iproute2. Swiss army knife for network applications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM crashvb/supervisord:ubuntu
 LABEL maintainer="Richard Davis <crashvb@gmail.com>"
 
 # Install packages, download files ...
-RUN docker-apt fcgiwrap nginx php-apcu php7.0-cli php7.0-fpm
+RUN docker-apt fcgiwrap nginx php-apcu php7.0-cli php7.0-fpm iproute2
 
 # Configure: hello
 ADD hello.* /var/hello/


### PR DESCRIPTION
iproute2 is quite useful for network applications, which, pretty much, what Docker was designed for. Maybe it would make even more sense placing iproute2 closer to scratch image in the tree of images?

An unrelated note. The "hello" makes nginx image more user friendly. It was pleasant for me to bring this container up and in less than a minute have working web site. On the other hand it makes it impure. I want to base my mediawiki image on top of your nginx image. Do we have to always instruct all descendant images via their Dockerfiles to undo this "hello"?